### PR TITLE
Updating node version support in package.js to 0.4.x or 0.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index",
   "engines": {
-    "node": "~0.4.7"
+    "node": "0.4.x | 0.6.x"
   },
   "dependencies": {
       "underscore" : "1.1.7"


### PR DESCRIPTION
I'm unable to install connect-redirecthost with npm 1.0.x on a node 0.6.x system due to the engine specified in the package as only supporting ~0.4.7. This change updates the package to indicate support for 0.4.x or 0.6.x.
