### PR TITLE
Updating node version to support >= 0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index",
   "engines": {
-    "node": "~0.4.7"
+    "node": ">= 0.4.7"
   },
   "dependencies": {
       "underscore" : "1.1.7"


### PR DESCRIPTION
Updating node version support to 0.4.7 or greater as npm 1.x will not install this module on node 0.6.x systems.
