### PR TITLE
Allow to use this module behind a proxy by using hostname

### DIFF
--- a/lib/redirectHost.js
+++ b/lib/redirectHost.js
@@ -137,7 +137,7 @@ exports.redirectHost = function(options) {
 
 function createHandler(to, except, pathFunc, protocol) {
     return function(req, res, next) {
-        var host = (req.header('host') || '').split(':')[0]; // strip port from host
+        var host = req.hostname || '';
         var url = req.url;
 
         if (host in except) {

--- a/test/redirectHost.test.js
+++ b/test/redirectHost.test.js
@@ -35,7 +35,7 @@ var mockRequest = function(url){
         return this.headers[name.toLowerCase()];
     };
 
-    req.headers['host'] = urlParts.host;
+    req.hostname = urlParts.hostname;
     req.url = (urlParts.pathname || '') + (urlParts.search || '');
 
     return req;


### PR DESCRIPTION
## Description 

Express provide the field `req.hostname` so you do not have to manually remove the port, moreover, this field is correctly populated if you are behind a proxy 

http://expressjs.com/fr/api.html#req.hostname